### PR TITLE
Run go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/bradleyfalzon/ghinstallation/v2
 
-go 1.13
+go 1.21
+
+toolchain go1.22.0
 
 require (
 	github.com/golang-jwt/jwt/v4 v4.5.0


### PR DESCRIPTION
Locally I'm running Go 1.22.3 and VS Code had trouble loading the workspace; it needed to run `go mod tidy` first. 