### PR TITLE
Support clientID in addition to appID

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -21,39 +21,80 @@ import (
 //
 // See https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/
 type AppsTransport struct {
-	BaseURL string            // BaseURL is the scheme and host for GitHub API, defaults to https://api.github.com
-	Client  Client            // Client to use to refresh tokens, defaults to http.Client with provided transport
-	tr      http.RoundTripper // tr is the underlying roundtripper being wrapped
-	signer  Signer            // signer signs JWT tokens.
-	appID   int64             // appID is the GitHub App's ID
+	BaseURL  string            // BaseURL is the scheme and host for GitHub API, defaults to https://api.github.com
+	Client   Client            // Client to use to refresh tokens, defaults to http.Client with provided transport
+	tr       http.RoundTripper // tr is the underlying roundtripper being wrapped
+	signer   Signer            // signer signs JWT tokens.
+	appID    int64             // appID is the GitHub App's ID. Deprecated: use clientID instead.
+	clientID string            // clientID is the GitHub App's client ID. This is preferred over App ID, and they are interchangeable.
 }
 
-// NewAppsTransportKeyFromFile returns a AppsTransport using a private key from file.
-func NewAppsTransportKeyFromFile(tr http.RoundTripper, appID int64, privateKeyFile string) (*AppsTransport, error) {
+// NewAppsTransportKeyFromFile returns an AppsTransport using a private key from file.
+func NewAppsTransportKeyFromFile(tr http.RoundTripper, clientID string, privateKeyFile string) (*AppsTransport, error) {
 	privateKey, err := os.ReadFile(privateKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("could not read private key: %s", err)
 	}
-	return NewAppsTransport(tr, appID, privateKey)
+	return NewAppsTransport(tr, clientID, privateKey)
 }
 
-// NewAppsTransport returns a AppsTransport using private key. The key is parsed
+// NewAppsTransportKeyFromFileWithAppID returns an AppsTransport using a private key from file
+// using the appID instead of the clientID. Deprecated: Use NewAppsTransportKeyFromFile instead.
+func NewAppsTransportKeyFromFileWithAppID(tr http.RoundTripper, appID int64, privateKeyFile string) (*AppsTransport, error) {
+	privateKey, err := os.ReadFile(privateKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("could not read private key: %s", err)
+	}
+	return NewAppsTransportWithAppId(tr, appID, privateKey)
+}
+
+// NewAppsTransport returns an AppsTransport using private key. The key is parsed
 // and if any errors occur the error is non-nil.
 //
 // The provided tr http.RoundTripper should be shared between multiple
 // installations to ensure reuse of underlying TCP connections.
 //
 // The returned Transport's RoundTrip method is safe to be used concurrently.
-func NewAppsTransport(tr http.RoundTripper, appID int64, privateKey []byte) (*AppsTransport, error) {
+func NewAppsTransport(tr http.RoundTripper, clientID string, privateKey []byte) (*AppsTransport, error) {
 	key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKey)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse private key: %s", err)
 	}
-	return NewAppsTransportFromPrivateKey(tr, appID, key), nil
+	return NewAppsTransportFromPrivateKey(tr, clientID, key), nil
+}
+
+// NewAppsTransportWithAppId returns an AppsTransport using private key when given an appID instead of clientID.
+// Deprecated: use NewAppsTransport instead
+// The key is parsed
+// and if any errors occur the error is non-nil.
+//
+// The provided tr http.RoundTripper should be shared between multiple
+// installations to ensure reuse of underlying TCP connections.
+//
+// The returned Transport's RoundTrip method is safe to be used concurrently.
+func NewAppsTransportWithAppId(tr http.RoundTripper, appID int64, privateKey []byte) (*AppsTransport, error) {
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse private key: %s", err)
+	}
+	return NewAppsTransportFromPrivateKeyWithAppID(tr, appID, key), nil
 }
 
 // NewAppsTransportFromPrivateKey returns an AppsTransport using a crypto/rsa.(*PrivateKey).
-func NewAppsTransportFromPrivateKey(tr http.RoundTripper, appID int64, key *rsa.PrivateKey) *AppsTransport {
+func NewAppsTransportFromPrivateKey(tr http.RoundTripper, clientID string, key *rsa.PrivateKey) *AppsTransport {
+	return &AppsTransport{
+		BaseURL:  apiBaseURL,
+		Client:   &http.Client{Transport: tr},
+		tr:       tr,
+		signer:   NewRSASigner(jwt.SigningMethodRS256, key),
+		clientID: clientID,
+	}
+}
+
+// NewAppsTransportFromPrivateKeyWithAppID returns an AppsTransport using a crypto/rsa.(*PrivateKey)
+// when given an appID instead of a clientID.
+// Deprecated: use NewAppsTransportWithPrivateKey instead
+func NewAppsTransportFromPrivateKeyWithAppID(tr http.RoundTripper, appID int64, key *rsa.PrivateKey) *AppsTransport {
 	return &AppsTransport{
 		BaseURL: apiBaseURL,
 		Client:  &http.Client{Transport: tr},
@@ -63,7 +104,29 @@ func NewAppsTransportFromPrivateKey(tr http.RoundTripper, appID int64, key *rsa.
 	}
 }
 
-func NewAppsTransportWithOptions(tr http.RoundTripper, appID int64, opts ...AppsTransportOption) (*AppsTransport, error) {
+// NewAppsTransportWithAppIDWithOptions returns an *AppsTransport configured with the given options.
+func NewAppsTransportWithOptions(tr http.RoundTripper, clientID string, opts ...AppsTransportOption) (*AppsTransport, error) {
+	t := &AppsTransport{
+		BaseURL:  apiBaseURL,
+		Client:   &http.Client{Transport: tr},
+		tr:       tr,
+		clientID: clientID,
+	}
+	for _, fn := range opts {
+		fn(t)
+	}
+
+	if t.signer == nil {
+		return nil, errors.New("no signer provided")
+	}
+
+	return t, nil
+}
+
+// NewAppsTransportWithAppIDWithOptions returns an *AppsTransport configured with the given options
+// when given an appID instead of a clientID.
+// Deprecated: use NewAppsTransportWithAppIDWithOptions instead
+func NewAppsTransportWithAppIDWithOptions(tr http.RoundTripper, appID int64, opts ...AppsTransportOption) (*AppsTransport, error) {
 	t := &AppsTransport{
 		BaseURL: apiBaseURL,
 		Client:  &http.Client{Transport: tr},
@@ -88,10 +151,18 @@ func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Truncate them before passing to jwt-go.
 	iss := time.Now().Add(-30 * time.Second).Truncate(time.Second)
 	exp := iss.Add(2 * time.Minute)
+
+	// prefer clientID when given, fall back to appID when not
+	// TODO(kfcampbell): add test coverage for this behavior
+	issuer := t.clientID
+	if issuer == "" {
+		issuer = strconv.FormatInt(t.appID, 10)
+	}
+
 	claims := &jwt.RegisteredClaims{
 		IssuedAt:  jwt.NewNumericDate(iss),
 		ExpiresAt: jwt.NewNumericDate(exp),
-		Issuer:    strconv.FormatInt(t.appID, 10),
+		Issuer:    issuer,
 	}
 
 	ss, err := t.signer.Sign(claims)
@@ -107,10 +178,17 @@ func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 // AppID returns the appID of the transport
+// Deprecated: prefer ClientID where possible
 func (t *AppsTransport) AppID() int64 {
 	return t.appID
 }
 
+// ClientID returns the clientID of the transport
+func (t *AppsTransport) ClientID() string {
+	return t.clientID
+}
+
+// AppsTransportOption is a functional option for configuring an AppsTransport
 type AppsTransportOption func(*AppsTransport)
 
 // WithSigner configures the AppsTransport to use the given Signer for generating JWT tokens.

--- a/appsTransport_test.go
+++ b/appsTransport_test.go
@@ -27,7 +27,7 @@ func TestNewAppsTransportKeyFromFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = NewAppsTransportKeyFromFile(&http.Transport{}, appID, tmpfile.Name())
+	_, err = NewAppsTransportKeyFromFileWithAppID(&http.Transport{}, appID, tmpfile.Name())
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -57,7 +57,7 @@ func TestAppsTransport(t *testing.T) {
 		},
 	}
 
-	tr, err := NewAppsTransport(check, appID, key)
+	tr, err := NewAppsTransportWithAppId(check, appID, key)
 	if err != nil {
 		t.Fatalf("error creating transport: %v", err)
 	}
@@ -101,7 +101,7 @@ func TestJWTExpiry(t *testing.T) {
 		},
 	}
 
-	tr := NewAppsTransportFromPrivateKey(check, appID, key)
+	tr := NewAppsTransportFromPrivateKeyWithAppID(check, appID, key)
 	req := httptest.NewRequest(http.MethodGet, "http://example.com", new(bytes.Buffer))
 	req.Header.Add("Accept", customHeader)
 	if _, err := tr.RoundTrip(req); err != nil {
@@ -124,7 +124,7 @@ func TestCustomSigner(t *testing.T) {
 		},
 	}
 
-	tr, err := NewAppsTransportWithOptions(check, appID, WithSigner(&noopSigner{}))
+	tr, err := NewAppsTransportWithAppIDWithOptions(check, appID, WithSigner(&noopSigner{}))
 	if err != nil {
 		t.Fatalf("NewAppsTransportWithOptions: %v", err)
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -77,7 +77,7 @@ func TestNew(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	tr, err := New(&http.Transport{}, appID, installationID, key)
+	tr, err := NewTransportFromAppID(&http.Transport{}, appID, installationID, key)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -142,7 +142,7 @@ func TestNewKeyFromFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = NewKeyFromFile(&http.Transport{}, appID, installationID, tmpfile.Name())
+	_, err = NewKeyFromFileWithAppID(&http.Transport{}, appID, installationID, tmpfile.Name())
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -164,7 +164,7 @@ func TestNew_appendHeader(t *testing.T) {
 	}
 	req.Header.Add("Accept", myheader)
 
-	tr, err := New(&http.Transport{}, appID, installationID, key)
+	tr, err := NewTransportFromAppID(&http.Transport{}, appID, installationID, key)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -259,7 +259,7 @@ func TestRefreshTokenWithParameters(t *testing.T) {
 		},
 	}
 
-	tr, err := New(roundTripper, appID, installationID, key)
+	tr, err := NewTransportFromAppID(roundTripper, appID, installationID, key)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
@@ -342,7 +342,7 @@ func TestRefreshTokenWithTrailingSlashBaseURL(t *testing.T) {
 		},
 	}
 
-	tr, err := New(roundTripper, appID, installationID, key)
+	tr, err := NewTransportFromAppID(roundTripper, appID, installationID, key)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}


### PR DESCRIPTION
Since Go doesn't support overloading, this PR adds additional functions to support passing the clientID as well as the appID when performing App authentication. 

It has been successfully manually testing using a local version of `go-sdk`.  