### PR TITLE
Bump JWT expiry time from 2 --> 10 minutes

### DIFF
--- a/appsTransport.go
+++ b/appsTransport.go
@@ -150,7 +150,7 @@ func (t *AppsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// while the jwt-go library serializes to fractional timestamps.
 	// Truncate them before passing to jwt-go.
 	iss := time.Now().Add(-30 * time.Second).Truncate(time.Second)
-	exp := iss.Add(2 * time.Minute)
+	exp := iss.Add(10 * time.Minute)
 
 	// prefer clientID when given, fall back to appID when not
 	// TODO(kfcampbell): add test coverage for this behavior


### PR DESCRIPTION
This change keeps us consistent with the .NET changes being worked on in https://github.com/octokit/dotnet-sdk/pull/70. 